### PR TITLE
Refonte UI/UX : landing riche + flux quiz premium (teaser → gate, icônes)

### DIFF
--- a/src/components/Quiz/EnhancedAnswerOption.tsx
+++ b/src/components/Quiz/EnhancedAnswerOption.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { Check } from "lucide-react";
 
 interface EnhancedAnswerOptionProps {
   option: {
@@ -53,9 +54,9 @@ export const EnhancedAnswerOption = ({
             initial={{ scale: 0, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ type: "spring", stiffness: 400, damping: 15 }}
-            className="absolute right-4 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold"
+            className="absolute right-4 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center"
           >
-            ✓
+            <Check className="w-3.5 h-3.5" strokeWidth={3} />
           </motion.span>
         )}
         <span className="block pr-8">{option.label}</span>

--- a/src/components/Quiz/Results/Results.tsx
+++ b/src/components/Quiz/Results/Results.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useQuiz } from "../QuizContext";
 import { ResultsLoading } from "./ResultsLoading";
 import { SimpleHormoneResults } from "./components/SimpleHormoneResults";
-import { EmailCaptureScreen } from "./components/EmailCaptureScreen";
+import { ProfileTeaserGate } from "./components/ProfileTeaserGate";
 import { AnimatePresence } from "framer-motion";
 import { useEmailSubscription } from "./EmailSubscriptionHandler";
 
@@ -57,9 +57,10 @@ export const Results = ({ onResetQuiz }: { onResetQuiz: () => void }) => {
             </button>
           </div>
         </div>
-      ) : phase === "email" ? (
-        <EmailCaptureScreen
+      ) : phase === "email" && state.hormoneProfile ? (
+        <ProfileTeaserGate
           key="email"
+          hormoneProfile={state.hormoneProfile}
           email={email}
           setEmail={setEmail}
           firstName={firstName}

--- a/src/components/Quiz/Results/components/ProfileTeaserGate.tsx
+++ b/src/components/Quiz/Results/components/ProfileTeaserGate.tsx
@@ -1,7 +1,11 @@
 import { motion } from "framer-motion";
-import { ArrowRight, Sparkles } from "lucide-react";
+import { ArrowRight, Lock, Sparkles } from "lucide-react";
+import { HormoneProfile } from "../../utils/hormoneProfileCalculator";
+import { getHormoneProfileDetails } from "../utils/HormoneProfileDetails";
+import { getProfileIcon, getProfileTheme } from "../../utils/profileVisuals";
 
-interface EmailCaptureScreenProps {
+interface ProfileTeaserGateProps {
+  hormoneProfile: HormoneProfile;
   email: string;
   setEmail: (email: string) => void;
   firstName: string;
@@ -13,7 +17,8 @@ interface EmailCaptureScreenProps {
   onSkip?: () => void;
 }
 
-export const EmailCaptureScreen = ({
+export const ProfileTeaserGate = ({
+  hormoneProfile,
   email,
   setEmail,
   firstName,
@@ -23,7 +28,17 @@ export const EmailCaptureScreen = ({
   setGdprConsent,
   handleSubmit,
   onSkip,
-}: EmailCaptureScreenProps) => {
+}: ProfileTeaserGateProps) => {
+  const profile = getHormoneProfileDetails(hormoneProfile.type);
+  const theme = getProfileTheme(profile.colorTheme);
+  const ProfileIcon = getProfileIcon(profile.icon);
+
+  const locked = [
+    "Tes 3 premiers gestes sur-mesure",
+    "Ta recommandation programme personnalisée",
+    "Ton guide complet, envoyé par email",
+  ];
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -32,33 +47,59 @@ export const EmailCaptureScreen = ({
       transition={{ duration: 0.5 }}
       className="flex items-center justify-center px-6 py-12 min-h-[calc(100vh-140px)]"
     >
-      <div className="max-w-[480px] w-full bg-card border border-border rounded-xl shadow-md p-8 space-y-6 text-center">
-        {/* Icon + progression */}
+      <div className="max-w-[480px] w-full bg-card border border-border rounded-xl shadow-md p-8 space-y-6">
+
+        {/* ── Révélation du profil (gratuit) ── */}
         <motion.div
           initial={{ scale: 0.9, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
+          transition={{ delay: 0.15, duration: 0.4 }}
+          className="text-center"
         >
           <p className="font-body uppercase text-[13px] text-soft tracking-[1.5px] mb-4">
-            Dernière étape
+            Ton profil peau
           </p>
           <div className="mb-4 flex justify-center">
-            <div className="w-[72px] h-[72px] rounded-full bg-brand-soft flex items-center justify-center">
-              <Sparkles className="w-8 h-8 text-primary" />
+            <div
+              className="w-[72px] h-[72px] rounded-full flex items-center justify-center"
+              style={{ background: theme.halo, boxShadow: `0 0 0 9px ${theme.ring}` }}
+            >
+              <ProfileIcon className="w-8 h-8" style={{ color: theme.icon }} strokeWidth={1.75} />
             </div>
           </div>
-          <h1 className="font-heading text-[1.8rem] lg:text-[2.2rem] font-bold text-violet-deep mb-3">
-            Ton profil est prêt
+          <h1 className="font-heading text-[1.7rem] lg:text-[2rem] font-bold text-foreground mb-3">
+            {profile.title}
           </h1>
-          <p className="text-muted-foreground text-base leading-relaxed font-body">
-            Entre ton email pour recevoir tes résultats + un guide avec les 3 premiers
-            gestes adaptés à ta peau.
+          <p className="text-muted-foreground text-[15px] leading-relaxed font-body">
+            {profile.tuEs}
           </p>
         </motion.div>
 
+        {/* ── Ce qui reste à débloquer ── */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3, duration: 0.4 }}
+          className="bg-brand-soft rounded-lg p-5"
+        >
+          <p className="font-body text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-primary" />
+            Débloque ton plan complet
+          </p>
+          <ul className="space-y-2.5">
+            {locked.map((item) => (
+              <li key={item} className="flex items-center gap-2.5 font-body text-[14px] text-muted-foreground">
+                <Lock className="w-3.5 h-3.5 text-primary flex-shrink-0" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </motion.div>
+
+        {/* ── Formulaire email ── */}
         <motion.form
           onSubmit={handleSubmit}
-          className="space-y-4 text-left"
+          className="space-y-4"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.4, duration: 0.4 }}
@@ -100,13 +141,13 @@ export const EmailCaptureScreen = ({
             disabled={isLoading || !email || !firstName || !gdprConsent}
             className="w-full font-body text-base font-bold text-primary-foreground bg-brand-gradient rounded-full py-4 shadow-glow transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/30"
           >
-            {isLoading ? "..." : "Voir mes résultats"}
+            {isLoading ? "..." : "Voir mon plan complet"}
             {!isLoading && <ArrowRight className="w-5 h-5" />}
           </button>
         </motion.form>
 
         <motion.p
-          className="text-xs text-soft font-body"
+          className="text-xs text-soft font-body text-center"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.6 }}
@@ -115,15 +156,19 @@ export const EmailCaptureScreen = ({
         </motion.p>
 
         {onSkip && (
-          <motion.button
-            onClick={onSkip}
-            className="text-sm text-soft underline hover:text-foreground transition-colors font-body"
+          <motion.div
+            className="text-center"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.8 }}
           >
-            Voir mes résultats sans donner mon email
-          </motion.button>
+            <button
+              onClick={onSkip}
+              className="text-[13px] text-soft/80 underline hover:text-foreground transition-colors font-body"
+            >
+              Voir un aperçu sans mon email
+            </button>
+          </motion.div>
         )}
       </div>
     </motion.div>

--- a/src/components/Quiz/Results/components/SimpleHormoneResults.tsx
+++ b/src/components/Quiz/Results/components/SimpleHormoneResults.tsx
@@ -1,28 +1,21 @@
 import { motion } from "framer-motion";
 import { HormoneProfile } from "../../utils/hormoneProfileCalculator";
 import { getHormoneProfileDetails } from "../utils/HormoneProfileDetails";
-import { ArrowRight } from "lucide-react";
+import { getProfileIcon, getProfileTheme } from "../../utils/profileVisuals";
+import { ArrowRight, Check, Mail } from "lucide-react";
 
 interface SimpleHormoneResultsProps {
   hormoneProfile: HormoneProfile;
   onResetQuiz: () => void;
 }
 
-// Halo coloré selon le profil — reste dans la famille chromatique de la marque
-const THEME_HALO: Record<string, { halo: string; ring: string }> = {
-  red:    { halo: "#F9D5E5", ring: "rgba(212,100,154,0.22)" },
-  pink:   { halo: "#FBEAF2", ring: "rgba(224,119,173,0.22)" },
-  purple: { halo: "#EDE5F4", ring: "rgba(138,107,160,0.22)" },
-  blue:   { halo: "#EBE0F5", ring: "rgba(168,148,226,0.22)" },
-  green:  { halo: "#E3F0E6", ring: "rgba(120,170,130,0.22)" },
-};
-
 export const SimpleHormoneResults = ({
   hormoneProfile,
   onResetQuiz,
 }: SimpleHormoneResultsProps) => {
   const profile = getHormoneProfileDetails(hormoneProfile.type);
-  const theme = THEME_HALO[profile.colorTheme] ?? THEME_HALO.pink;
+  const theme = getProfileTheme(profile.colorTheme);
+  const ProfileIcon = getProfileIcon(profile.icon);
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -60,7 +53,7 @@ export const SimpleHormoneResults = ({
               className="w-20 h-20 rounded-full flex items-center justify-center"
               style={{ background: theme.halo, boxShadow: `0 0 0 10px ${theme.ring}` }}
             >
-              <span className="text-[36px]">{profile.emoji}</span>
+              <ProfileIcon className="w-9 h-9" style={{ color: theme.icon }} strokeWidth={1.75} />
             </div>
           </div>
           <h1 className="font-heading text-[28px] lg:text-[32px] font-bold text-foreground">
@@ -132,14 +125,15 @@ export const SimpleHormoneResults = ({
           <p className="text-foreground font-medium mb-3 font-body">Tu recevras aussi par email :</p>
           <ul className="space-y-2 text-muted-foreground font-body">
             {["Ton profil détaillé", "3 conseils adaptés", "Ressources gratuites"].map((item) => (
-              <li key={item} className="flex items-center gap-2">
-                <span className="text-primary font-bold">✓</span>
+              <li key={item} className="flex items-center gap-2.5">
+                <Check className="w-4 h-4 text-primary flex-shrink-0" strokeWidth={3} />
                 <span>{item}</span>
               </li>
             ))}
           </ul>
-          <p className="text-sm mt-4 italic text-soft font-body">
-            Pas prête ? Pas de souci. Le guide arrive dans ta boîte. 💌
+          <p className="text-sm mt-4 italic text-soft font-body flex items-center gap-2">
+            <Mail className="w-4 h-4 flex-shrink-0" />
+            Pas prête ? Pas de souci. Le guide arrive dans ta boîte.
           </p>
         </motion.div>
 

--- a/src/components/Quiz/Welcome.tsx
+++ b/src/components/Quiz/Welcome.tsx
@@ -12,6 +12,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { HORMONE_PROFILE_DETAILS } from "./Results/utils/HormoneProfileDetails";
+import { getProfileIcon, getProfileTheme } from "./utils/profileVisuals";
 
 /* ── Visuel hero : photo fournie par le client (/public/hero.jpg).
    Fallback décoratif élégant si l'image est absente afin de ne jamais casser la page. ── */
@@ -82,7 +83,8 @@ const reassurance = [
 ];
 
 const profiles = Object.values(HORMONE_PROFILE_DETAILS).map((p) => ({
-  emoji: p.emoji,
+  Icon: getProfileIcon(p.icon),
+  theme: getProfileTheme(p.colorTheme),
   title: p.title,
 }));
 
@@ -232,7 +234,12 @@ export const Welcome = ({ onStart }: { onStart: () => void }) => {
               variants={fadeUp}
               className="inline-flex items-center gap-2.5 bg-card border border-border rounded-full pl-2.5 pr-5 py-2 card-hover"
             >
-              <span className="w-9 h-9 rounded-full surface-soft flex items-center justify-center text-lg">{p.emoji}</span>
+              <span
+                className="w-9 h-9 rounded-full flex items-center justify-center"
+                style={{ background: p.theme.halo }}
+              >
+                <p.Icon className="w-[18px] h-[18px]" style={{ color: p.theme.icon }} />
+              </span>
               <span className="font-body text-[15px] font-medium text-foreground">{p.title}</span>
             </motion.div>
           ))}

--- a/src/components/Quiz/utils/profileVisuals.tsx
+++ b/src/components/Quiz/utils/profileVisuals.tsx
@@ -1,0 +1,24 @@
+import { Flame, Moon, Sparkles, Calendar, Heart, type LucideIcon } from "lucide-react";
+
+/* Mapping nom d'icône (champ `icon` de HormoneProfileDetails) → composant Lucide.
+   Centralisé pour rester cohérent entre la home, le teaser et les résultats. */
+export const PROFILE_ICONS: Record<string, LucideIcon> = {
+  flame: Flame,
+  moon: Moon,
+  sparkles: Sparkles,
+  calendar: Calendar,
+  heart: Heart,
+};
+
+export const getProfileIcon = (icon: string): LucideIcon => PROFILE_ICONS[icon] ?? Sparkles;
+
+/* Halo + couleur d'icône par profil — reste dans la famille chromatique de la marque */
+export const PROFILE_THEME: Record<string, { halo: string; ring: string; icon: string }> = {
+  red:    { halo: "#FBEAF2", ring: "rgba(212,100,154,0.22)", icon: "#D4649A" },
+  pink:   { halo: "#FBEAF2", ring: "rgba(224,119,173,0.22)", icon: "#E077AD" },
+  purple: { halo: "#EDE5F4", ring: "rgba(138,107,160,0.22)", icon: "#8A6BA0" },
+  blue:   { halo: "#EBE0F5", ring: "rgba(168,148,226,0.22)", icon: "#8A6BA0" },
+  green:  { halo: "#E3F0E6", ring: "rgba(120,170,130,0.28)", icon: "#5E9A6E" },
+};
+
+export const getProfileTheme = (colorTheme: string) => PROFILE_THEME[colorTheme] ?? PROFILE_THEME.pink;


### PR DESCRIPTION
## Contexte

La page d'accueil était trop minimaliste (badge + titre + bouton) et n'incitait pas à compléter le quiz. En parallèle, les pages quiz portaient de la dette (couleurs en dur, emojis OS-dépendants, gate email peu optimisé). Cette PR transforme la home en landing qui « fait envie » et élève tout le parcours pour une cohérence premium de bout en bout.

## ✨ Page d'accueil — landing riche
- **Hero 2 colonnes** : titre avec accent en dégradé de marque, sous-titre, CTA animé, micro-réassurance + **slot image responsive** (`public/hero.jpg`) avec **fallback CSS élégant** si l'image est absente.
- **« Ce que tu vas découvrir »** : 4 cartes d'atouts.
- **Aperçu des 5 profils** : pastilles générées depuis les profils existants → crée la curiosité « lequel suis-je ? ».
- **Bandeau réassurance** + **CTA final**. Animations au scroll qui respectent `prefers-reduced-motion`.
- Header allégé, suppression des footers/orbs dupliqués.

## 📈 Flux résultats — teaser → gate (conversion)
- Révélation **gratuite** du profil (icône + nom + phrase « Tu es… ») juste après le quiz.
- **Mur de valeur** : encart « Débloque ton plan complet » (3 gestes, reco programme, guide email verrouillés).
- Email → débloque les résultats complets. Skip conservé mais **discret**.
- Nouveau composant `ProfileTeaserGate` (remplace `EmailCaptureScreen`).

## 🎭 Système d'icônes premium
- Fin des emojis OS-dépendants : les **5 profils** passent sur icônes Lucide via le champ `icon` **déjà présent** dans les données, dans des pastilles colorées (`colorTheme`).
- `✓` → `Check`, `💌` → `Mail` sur tout le parcours actif.
- Helper centralisé `profileVisuals.tsx` (icône + thème couleur par profil), réutilisé sur la home, le teaser et les résultats.

## 🎨 Tokens
- Nouveaux : `surface-soft`, `text-soft`, utilitaires `.bg-brand-gradient` / `.bg-brand-soft` / `.text-brand-gradient`, animation `float`, garde-fou global `prefers-reduced-motion`.

## ✅ Vérification
- `npm run build` : OK (aucune erreur TS/Vite).
- `npm run dev` : l'app répond en HTTP 200 ; parcours home → quiz → teaser → résultats fonctionnel.
- Responsive mobile/desktop, focus clavier accessible sur boutons/inputs.

## ⚠️ À noter
- **Image hero à fournir** : déposer `public/hero.jpg` (~1080×1350, webp/jpg) ou m'envoyer une URL directe. En attendant, le fallback CSS s'affiche.
- Chiffres de preuve sociale laissés en placeholder honnête (aucun faux témoignage/chiffre inventé).

## Fichiers principaux
- `src/components/Quiz/Welcome.tsx` — landing riche + hero
- `src/components/Quiz/Results/components/ProfileTeaserGate.tsx` — teaser → gate (nouveau)
- `src/components/Quiz/Results/Results.tsx` — câblage du nouveau flux
- `src/components/Quiz/utils/profileVisuals.tsx` — icônes + thème par profil (nouveau)
- `src/components/Quiz/Results/components/SimpleHormoneResults.tsx`, `EnhancedAnswerOption.tsx`, `QuizProgressBar.tsx`, `pages/Index.tsx`
- `src/index.css`, `tailwind.config.ts` — tokens

https://claude.ai/code/session_01BX95s3CrsaAp65UpSPzmoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BX95s3CrsaAp65UpSPzmoG)_